### PR TITLE
Update NuGet Package URLs

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -16,8 +16,8 @@
 
 	<PropertyGroup>
 		<Authors>Matthias Gernand</Authors>
-		<RepositoryUrl>https://github.com/fluxera/Fluxera.Guard</RepositoryUrl>
-		<PackageProjectUrl>https://github.com/fluxera/Fluxera.Guard</PackageProjectUrl>
+		<RepositoryUrl>https://github.com/fluxera/Fluxera.Enumeration</RepositoryUrl>
+		<PackageProjectUrl>https://github.com/fluxera/Fluxera.Enumeration</PackageProjectUrl>
 		<PackageIcon>icon.png</PackageIcon>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>


### PR DESCRIPTION
Hey Fluxera Team!
I noticed some wrong links in your NuGet package definition, so I simply created this small PR.

- Updates `RepositoryUrl` and `PackageProjectUrl` to point to correct GitHub repository.